### PR TITLE
fix: circular import in watch_orderbook.py

### DIFF
--- a/examples/watch_orderbook.py
+++ b/examples/watch_orderbook.py
@@ -1,7 +1,7 @@
 """Simple example demonstrating how to watch a market's orderbook using WebSocket ETH RPC."""
 import sys
 
-from examples.utils import MARKET_ADDRESS
+from utils import MARKET_ADDRESS
 
 sys.path.append(".")
 from gte_py.api.chain.clob import ICLOB


### PR DESCRIPTION
- Changed line 4 from 'from examples.utils' to 'from utils'
- Fixes module import error when running from different directories