### PR TITLE
fix circular dependency issue

### DIFF
--- a/examples/watch_clob_events.py
+++ b/examples/watch_clob_events.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 from datetime import datetime, timedelta
 
-from web3 import AsyncWeb3
 from examples.utils import WALLET_ADDRESS, MARKET_ADDRESS
 from gte_py.api.chain.clob import ICLOB
 from gte_py.api.chain.event_source import EventStream
@@ -164,7 +163,7 @@ async def main():
 
     # Initialize CLOB contract wrapper
     print(f"Initializing CLOB contract at {MARKET_ADDRESS}...")
-    clob = client.clob.get_clob(AsyncWeb3.to_checksum_address(MARKET_ADDRESS))
+    clob = client.clob.get_clob(MARKET_ADDRESS)
     
     # Example 1: Watch for all market activity for 30 seconds
     await watch_all_market_activity(clob, duration_seconds=30)

--- a/examples/watch_orderbook.py
+++ b/examples/watch_orderbook.py
@@ -1,9 +1,8 @@
 """Simple example demonstrating how to watch a market's orderbook using WebSocket ETH RPC."""
 import sys
 
-from examples.utils import MARKET_ADDRESS
-
 sys.path.append(".")
+from utils import MARKET_ADDRESS
 from gte_py.api.chain.clob import ICLOB
 from gte_py.api.chain.utils import make_web3
 from gte_py.clients import Client, MarketClient
@@ -12,7 +11,6 @@ from gte_py.configs import TESTNET_CONFIG
 import argparse
 import asyncio
 import logging
-import os
 
 from rich.console import Console
 from rich.table import Table
@@ -126,6 +124,7 @@ class OrderbookWatcher:
         self.running = True
         market = await client.info.get_market(self.market_address)
         self.orderbook_client = client.market
+
         # Initialize MarketClient if we have a client
         async def refresh_snapshot():
             while self.running:

--- a/src/gte_py/api/rest/models.py
+++ b/src/gte_py/api/rest/models.py
@@ -1,6 +1,11 @@
 """TypedDict models for REST API responses."""
 
-from typing import TypedDict, Optional, Literal
+from typing import TypedDict, Any
+
+from eth_utils import to_checksum_address
+from hexbytes import HexBytes
+
+from gte_py.models import Market, MarketType, Token, Position, Trade, OrderSide
 
 
 class TokenDetail(TypedDict):
@@ -17,6 +22,19 @@ class TokenDetail(TypedDict):
     volume24HrUsd: float
     marketCapUsd: float
     marketType: str
+
+
+def token_detail_to_model(data: TokenDetail) -> Token:
+    """Create an Asset object from API response data."""
+    address = to_checksum_address(data["address"])
+
+    return Token(
+        address=address,
+        decimals=data["decimals"],
+        name=data["name"],
+        symbol=data["symbol"],
+        total_supply=data["totalSupply"],
+    )
 
 
 class MarketDetail(TypedDict):
@@ -36,3 +54,47 @@ class MarketDetail(TypedDict):
     createdAt: int
     tvlUsd: float
     liquidityUsd: float
+
+
+def market_detail_to_model(data: MarketDetail) -> Market:
+    """Create a Market object from API response data."""
+    contract_address = data["address"]
+
+    return Market(
+        address=to_checksum_address(contract_address),
+        market_type=MarketType(data["marketType"]),
+        base=token_detail_to_model(data["baseToken"]),
+        quote=token_detail_to_model(data["quoteToken"]),
+        price=data.get("price"),
+        volume_24hr_usd=data.get("volume24HrUsd"),
+    )
+
+
+def position_to_model(data: dict[str, Any]) -> Position:
+    """Create a Position object from API response data."""
+    return Position(
+        market=market_detail_to_model(data["market"]),
+        user=to_checksum_address(data["user"]),
+        token0_amount=data.get("token0Amount", 0.0),
+        token1_amount=data.get("token1Amount", 0.0),
+    )
+
+
+def trade_to_model(cls, data: dict[str, Any]) -> Trade:
+    """Create a Trade object from API response data."""
+
+    side = OrderSide.from_str(data["side"])
+    tx_hash = HexBytes(data["txnHash"])
+    maker = data["maker"] and to_checksum_address(data["maker"]) or None
+    taker = data["taker"] and to_checksum_address(data["taker"]) or None
+
+    return cls(
+        market_address=to_checksum_address(data['marketAddress']),
+        timestamp=data["timestamp"],
+        price=int(data["price"]),
+        size=int(data["size"]),
+        side=side,
+        tx_hash=tx_hash,
+        maker=maker,
+        taker=taker,
+    )

--- a/src/gte_py/clients/info/__init__.py
+++ b/src/gte_py/clients/info/__init__.py
@@ -9,6 +9,7 @@ from gte_py.api.chain.clob import ICLOB
 from gte_py.api.rest import RestApi
 from gte_py.api.chain.token_client import TokenClient
 from gte_py.api.chain.clob_client import CLOBClient
+from gte_py.api.rest.models import market_detail_to_model, token_detail_to_model
 from gte_py.models import Token, Market, MarketType
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ class InfoClient:
         response = await self._rest.get_tokens(
             creator=creator, limit=limit, offset=offset
         )
-        return [Token.from_api(asset_data) for asset_data in response.get("assets", [])]
+        return [token_detail_to_model(asset_data) for asset_data in response.get("assets", [])]
 
     async def get_markets(
         self,
@@ -88,7 +89,7 @@ class InfoClient:
             token_address=token_address,
         )
 
-        markets = [Market.from_api(market_data) for market_data in response]
+        markets = [market_detail_to_model(market_data) for market_data in response]
 
         return markets
 
@@ -106,7 +107,7 @@ class InfoClient:
             return self._markets[address]
 
         resp = await self._rest.get_market(address)
-        market = Market.from_api(resp)
+        market = market_detail_to_model(resp)
         self._markets[address] = market
         return market
 

--- a/src/gte_py/clients/market/trades.py
+++ b/src/gte_py/clients/market/trades.py
@@ -6,6 +6,7 @@ from eth_utils.address import to_checksum_address
 from hexbytes import HexBytes
 
 from gte_py.api.rest import RestApi, logger
+from gte_py.api.rest.models import trade_to_model
 from gte_py.api.ws import WebSocketApi, TradeData
 from gte_py.configs import NetworkConfig
 from gte_py.models import Market, Trade, OrderSide
@@ -35,7 +36,7 @@ class TradesClient:
         :return: The response from the API.
         """
         trades = await self._rest.get_trades(market, limit, offset)
-        return [Trade.from_api(trade) for trade in trades]
+        return [trade_to_model(trade) for trade in trades]
 
     # Trade methods
     async def subscribe_trades(

--- a/src/gte_py/clients/user.py
+++ b/src/gte_py/clients/user.py
@@ -13,6 +13,7 @@ from gte_py.api.chain.clob_factory import CLOBFactory
 from gte_py.api.chain.structs import OperatorRole
 from gte_py.api.rest import RestApi
 from gte_py.api.chain.token_client import TokenClient
+from gte_py.api.rest.models import trade_to_model
 from gte_py.configs import NetworkConfig
 from gte_py.models import Market, Order, Trade, OrderSide, OrderType, OrderStatus, TimeInForce
 
@@ -279,7 +280,7 @@ class UserClient:
             List of Order objects representing trades
         """
         response = await self._rest.get_user_trades(self._account, market.address, limit=limit, offset=offset)
-        return [Trade.from_api(trade) for trade in response]
+        return [trade_to_model(trade) for trade in response]
 
     async def get_open_orders(
             self, market: Market | None = None,


### PR DESCRIPTION
While from_api works well for dict, it's gonna cause circular dependency issue if we use TypedDict. This moved the conversion code to api.rest.models
supersedes #25 