### PR TITLE
Switches from float to decimal standard type and adds amm and launchpad support.

### DIFF
--- a/examples/amend_orders.py
+++ b/examples/amend_orders.py
@@ -9,9 +9,9 @@ from gte_py.configs import TESTNET_CONFIG
 from gte_py.models import OrderSide, TimeInForce
 
 from examples.utils import WALLET_PRIVATE_KEY
+from examples.constants import BTC_USD_CLOB
 
-# BTC CLOB
-MARKET_ADDRESS = "0x0F3642714B9516e3d17a936bAced4de47A6FFa5F"
+MARKET_ADDRESS = BTC_USD_CLOB
 
 
 async def main() -> None:

--- a/examples/amend_orders.py
+++ b/examples/amend_orders.py
@@ -2,6 +2,7 @@
 import sys
 sys.path.append(".")
 import asyncio
+from decimal import Decimal
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
@@ -9,6 +10,7 @@ from gte_py.models import OrderSide, TimeInForce
 
 from examples.utils import WALLET_PRIVATE_KEY
 
+# BTC CLOB
 MARKET_ADDRESS = "0x0F3642714B9516e3d17a936bAced4de47A6FFa5F"
 
 
@@ -24,23 +26,23 @@ async def main() -> None:
         order = await client.execution.place_limit_order(
             market=market,
             side=OrderSide.BUY,
-            amount= 10**18,
-            price=market.quote.convert_quantity_to_amount(50_000.0),
+            amount=Decimal("1.0"),
+            price=Decimal("50_000.0"),
             time_in_force=TimeInForce.GTC,
-            gas=50 * 10**6
+            return_order=True
         )
         
         print(f"Placed order: {order}")
-        
-        # Wait for 5 seconds
         await asyncio.sleep(5)
         
         # Since the price is low, we need to amend the order to $100,000 per BTC
         amended_order = await client.execution.amend_order(
             market=market,
-            order_id=order.order_id,
-            new_price=market.quote.convert_quantity_to_amount(100_000.0),
-            gas=50 * 10**6
+            order_id=int(order.get('args', {}).get('orderId', 0)),
+            side=OrderSide.BUY,
+            original_amount=Decimal("1.0"),
+            original_price=Decimal("50_000.0"),
+            new_price=Decimal("100_000.0"),
         )
         print(f"Amended order: {amended_order}")
 

--- a/examples/cancel_open_orders.py
+++ b/examples/cancel_open_orders.py
@@ -2,16 +2,14 @@
 import sys
 sys.path.append(".")
 import asyncio
-from eth_typing import ChecksumAddress
-from web3 import AsyncWeb3
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from examples.utils import WALLET_PRIVATE_KEY, WALLET_ADDRESS
 
-MARKET_ADDRESS: ChecksumAddress = AsyncWeb3.to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
-# BTC CLOB: 0x0F3642714B9516e3d17a936bAced4de47A6FFa5F
-# ETH CLOB: 0x5ca9f32d4ce7cc0f782213c446c2ae14b754a623
+from examples.constants import BTC_USD_CLOB
+
+MARKET_ADDRESS = BTC_USD_CLOB
 
 
 async def main():

--- a/examples/cancel_tx.py
+++ b/examples/cancel_tx.py
@@ -12,6 +12,10 @@ from examples.utils import (
     WALLET_PRIVATE_KEY
 )
 
+from examples.constants import BTC_USD_CLOB
+
+MARKET_ADDRESS = BTC_USD_CLOB
+
 
 async def cancel_transaction(client: GTEClient, tx_hash: str, gas_price_increase: float = 1.5) -> str:
     """

--- a/examples/constants.py
+++ b/examples/constants.py
@@ -1,0 +1,9 @@
+from eth_utils.address import to_checksum_address
+
+BTC_USD_CLOB = to_checksum_address("0x0f3642714b9516e3d17a936baced4de47a6ffa5f")
+ETH_USD_CLOB = to_checksum_address("0x5ca9f32d4ce7cc0f782213c446c2ae14b754a623")
+BTC_ETH_AMM = to_checksum_address("0x6bba3ff4b359392decd0b77239b7e795269fb550")
+
+# Token addresses
+BTC_ADDRESS = to_checksum_address("0x7f11aa697e05b75600354ac9acf8bb209225e932")
+LAUNCHPAD_TOKEN_ADDRESS = to_checksum_address("0x0eacb3fb580973bb37786942b24fe0022403080f")

--- a/examples/launchpad_trade.py
+++ b/examples/launchpad_trade.py
@@ -9,8 +9,7 @@ from web3 import AsyncWeb3
 from examples.utils import WALLET_PRIVATE_KEY
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
-
-LAUNCHPAD_TOKEN_ADDRESS: ChecksumAddress = AsyncWeb3.to_checksum_address("0x1fb2dAD77F45b62a6016E2c13c753FE965d90D0d")
+from examples.constants import LAUNCHPAD_TOKEN_ADDRESS
 
 async def main():
     config = TESTNET_CONFIG

--- a/examples/launchpad_trade.py
+++ b/examples/launchpad_trade.py
@@ -1,0 +1,62 @@
+"""Example of placing an order on a WETH market."""
+import sys
+sys.path.append(".")
+import asyncio
+from decimal import Decimal
+from eth_typing import ChecksumAddress
+from web3 import AsyncWeb3
+
+from examples.utils import WALLET_PRIVATE_KEY
+from gte_py.clients import GTEClient
+from gte_py.configs import TESTNET_CONFIG
+
+LAUNCHPAD_TOKEN_ADDRESS: ChecksumAddress = AsyncWeb3.to_checksum_address("0x1fb2dAD77F45b62a6016E2c13c753FE965d90D0d")
+
+async def main():
+    config = TESTNET_CONFIG
+        
+    async with GTEClient(config=config, wallet_private_key=WALLET_PRIVATE_KEY) as client:
+
+        launch_data = await client.info.get_market(LAUNCHPAD_TOKEN_ADDRESS)
+        print(launch_data)
+        
+        eth_amount = Decimal("0.001")
+        
+        order = await client.execution.launchpad_buy_exact_quote(
+            launch_token=launch_data.base,
+            quote_token=launch_data.quote,
+            quote_amount_in=Decimal(eth_amount),
+            slippage_tolerance=0.05,
+        )
+        print(f"Order posted: {order}")
+        print('-' * 50)
+        
+        # get quote for base amount to sell to get quote amount
+        quote = await client.execution.get_launchpad_quote_buy(
+            launch_token=launch_data.base,
+            quote_token=launch_data.quote,
+            quote_amount=eth_amount,
+        )
+        print(f"Quote: {quote}")
+
+        # sell base amount (launch token)to get quote amount
+        order = await client.execution.launchpad_sell_exact_base(
+            launch_token=launch_data.base,
+            quote_token=launch_data.quote,
+            base_amount_in=quote[0],
+            slippage_tolerance=0.05,
+        )
+        
+        print(f"Order posted: {order}")
+        print('-' * 50)
+        
+        # unwrap weth if you want to get eth back
+        weth_balance = await client.execution.get_weth_balance()
+        if weth_balance > 0:
+            _ = await client.execution.unwrap_eth(amount=weth_balance)
+        
+    return
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/place_order_weth.py
+++ b/examples/place_order_weth.py
@@ -3,17 +3,12 @@ import sys
 sys.path.append(".")
 import asyncio
 from decimal import Decimal
-from eth_typing import ChecksumAddress
-from web3 import AsyncWeb3
 
 from examples.utils import WALLET_PRIVATE_KEY
+from examples.constants import ETH_USD_CLOB
 from gte_py.clients import GTEClient
 from gte_py.api.chain.structs import OrderSide
 from gte_py.configs import TESTNET_CONFIG
-
-MARKET_ADDRESS: ChecksumAddress = AsyncWeb3.to_checksum_address("0x5ca9f32d4ce7cc0f782213c446c2ae14b754a623")
-# BTC CLOB: 0x0F3642714B9516e3d17a936bAced4de47A6FFa5F
-# ETH CLOB: 0x5ca9f32d4ce7cc0f782213c446c2ae14b754a623
 
 
 async def main():
@@ -24,7 +19,7 @@ async def main():
         
     async with GTEClient(config=config, wallet_private_key=WALLET_PRIVATE_KEY) as client:
 
-        market = await client.info.get_market(MARKET_ADDRESS)
+        market = await client.info.get_market(ETH_USD_CLOB)
         print(market)
         print('-' * 50)
         

--- a/examples/place_order_weth.py
+++ b/examples/place_order_weth.py
@@ -2,9 +2,10 @@
 import sys
 sys.path.append(".")
 import asyncio
+from decimal import Decimal
 from eth_typing import ChecksumAddress
 from web3 import AsyncWeb3
-import time
+
 from examples.utils import WALLET_PRIVATE_KEY
 from gte_py.clients import GTEClient
 from gte_py.api.chain.structs import OrderSide
@@ -25,43 +26,33 @@ async def main():
 
         market = await client.info.get_market(MARKET_ADDRESS)
         print(market)
+        print('-' * 50)
         
         eth_amount = 0.001
-        eth_amount_wei = market.base.convert_quantity_to_amount(eth_amount)
         
         # if using an eth clob market you have to wrap before selling eth and unwrap after buying eth
-        
-        # wrap the eth
-        weth_balance = await client.execution.get_weth_balance()
-        if weth_balance < eth_amount_wei*2:
-            await client.execution.wrap_eth(amount=eth_amount_wei*2 - weth_balance, gas=50 * 10**6)
-        
-        # buy eth
-        # if you want to use quote units, you can set amount_is_base=False
-        # amount is accepted in raw units (atoms, wei, etc.) unless you set amount_is_raw=False
-        order = await client.execution.place_market_order(  # type: ignore
+        order = await client.execution.place_market_order(
             market=market,
             side=OrderSide.BUY,
-            amount=eth_amount_wei,
+            amount=Decimal(eth_amount),
             slippage=0.05,
-            gas=50 * 10**6
         )
         
         print(f"Order posted: {order}")
         print('-' * 50)
         
         # or if you want to use amount in base units
-        order = await client.execution.place_market_order(  # type: ignore
+        order = await client.execution.place_market_order(
             market=market,
             side=OrderSide.BUY,
-            amount=eth_amount,
-            amount_is_raw=False,
+            amount=Decimal(eth_amount),
             slippage=0.05,
-            gas=50 * 10**6
         )
         
+        # unwrap weth
         weth_balance = await client.execution.get_weth_balance()
-        await client.execution.unwrap_eth(amount=weth_balance, gas=50 * 10**6)
+        if weth_balance > 0:
+            _ = await client.execution.unwrap_eth(amount=weth_balance)
 
         print(f"Order posted: {order}")
         

--- a/examples/place_orders.py
+++ b/examples/place_orders.py
@@ -3,15 +3,12 @@ from decimal import Decimal
 import sys
 sys.path.append(".")
 import asyncio
-from eth_utils.address import to_checksum_address
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from gte_py.models import OrderSide, TimeInForce
 from examples.utils import WALLET_PRIVATE_KEY, print_separator
-
-# BTC CLOB
-MARKET_ADDRESS = to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
+from examples.constants import BTC_USD_CLOB
 
 async def main():
     config = TESTNET_CONFIG
@@ -21,7 +18,7 @@ async def main():
         side = OrderSide.BUY
         size = Decimal('0.01')
         
-        market = await client.info.get_market(MARKET_ADDRESS)
+        market = await client.info.get_market(BTC_USD_CLOB)
         
         # Place a market order
         order = await client.execution.place_market_order(market, side, size, slippage=0.05)

--- a/examples/place_orders.py
+++ b/examples/place_orders.py
@@ -1,4 +1,5 @@
 """Example of placing a market and limit order on a BTC market."""
+from decimal import Decimal
 import sys
 sys.path.append(".")
 import asyncio
@@ -7,16 +8,10 @@ from eth_utils.address import to_checksum_address
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from gte_py.models import OrderSide, TimeInForce
-from examples.utils import WALLET_PRIVATE_KEY
+from examples.utils import WALLET_PRIVATE_KEY, print_separator
 
-
+# BTC CLOB
 MARKET_ADDRESS = to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
-
-def print_separator(title: str) -> None:
-    """Print a section separator."""
-    print("\n" + "=" * 50)
-    print(title)
-    print("=" * 50)
 
 async def main():
     config = TESTNET_CONFIG
@@ -24,32 +19,30 @@ async def main():
     async with GTEClient(config=config, wallet_private_key=WALLET_PRIVATE_KEY) as client:
         
         side = OrderSide.BUY
-        size = 0.01
+        size = Decimal('0.01')
         
         market = await client.info.get_market(MARKET_ADDRESS)
         
         # Place a market order
-        order = await client.execution.place_market_order(market, side, size, amount_is_raw=False, slippage=0.05, gas=50 * 10 ** 6)
+        order = await client.execution.place_market_order(market, side, size, slippage=0.05)
         
         print_separator(f"Market order placed: {order}")
-        
-        order_book = await client.info.get_order_book(MARKET_ADDRESS)
-        print(order_book)
+        best_bid, best_ask = await client.execution.get_tob(market)
+        print(f"Best bid: {best_bid}, Best ask: {best_ask}")    
         
         if side == OrderSide.BUY:
-            # For BUY orders, use the best ask price (lowest selling price)
-            price = market.quote.convert_quantity_to_amount(float(order_book['bids'][0]['price'])-10)
+            # For BUY orders, use the best bid price (highest buying price)
+            price = best_bid+1
         else:
-            # For SELL orders, use the best bid price (highest buying price)
-            price = market.quote.convert_quantity_to_amount(float(order_book['asks'][0]['price'])+10)
+            # For SELL orders, use the best ask price (lowest selling price)
+            price = best_ask-1
         
         print(f"TOB Price: {price}")
-        
+
         # Place a limit order
-        order = await client.execution.place_limit_order(market, side, size, price, amount_is_raw=False, time_in_force=TimeInForce.GTC, gas=50 * 10 ** 6)
+        order = await client.execution.place_limit_order(market, side, size, price, time_in_force=TimeInForce.GTC)
         
         print_separator(f"Limit order placed: {order}")
-    
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/query_markets.py
+++ b/examples/query_markets.py
@@ -1,60 +1,52 @@
-"""Example of querying a specific market from GTE."""
+"""Example of querying market information."""
 import sys
 sys.path.append(".")
 import asyncio
-
-from eth_typing import ChecksumAddress
-from eth_utils.address import to_checksum_address
+from decimal import Decimal
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
-from gte_py.models import Market
+from examples.constants import BTC_USD_CLOB
 
-
-MARKET_ADDRESS = to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
-
-async def display_market_info(client: GTEClient, market_address: ChecksumAddress) -> Market:
-    """Get and display market information."""
-
-    print(f"Using market: {market_address}")
-    market = await client.info.get_market(market_address)
-
-    print(f"Market type: {market['market_type']}")
-    print(f"Base token: {market['base']['symbol']} ({market['base']['address']})")
-    print(f"Quote token: {market['quote']['symbol']} ({market['quote']['address']})")
-
-    return market
-
-async def query_market_trades(client: GTEClient, market_address: ChecksumAddress) -> None:
-    """Query trades for a specific market."""
-    print("Market Trades Query")
-
-    # Get trades for the market
-    trades = await client.info.get_trades(market_address)
-
-    # Display trade information
-    print(f"Trades for market {market_address}:")
-    for trade in trades:
-        print('-' * 75)
-        print(f"  Txn: {trade['tx_hash'].to_0x_hex()}")
-        print(f"  Price: {trade['price']}")
-        print(f"  Size: {trade['size']}")
-        print(f"  Side: {trade['side']}")
-        print(f"  Timestamp: {trade['timestamp']}")
-    print('-' * 75)
-
-
-async def main() -> None:
-    """Run the market query example."""
-    print("GTE Market Query Example")
-
-    # Initialize client
-    async with GTEClient(config=TESTNET_CONFIG) as client:
+async def main():
+    config = TESTNET_CONFIG
         
-        market_address = MARKET_ADDRESS
-        _ = await display_market_info(client, market_address)
-        await query_market_trades(client, market_address)
-
+    async with GTEClient(config=config) as client:
+        
+        # Get all available markets
+        all_markets = await client.info.get_all_markets()
+        print("All available markets:")
+        for market in all_markets:
+            print(f"  {market.base.symbol}/{market.quote.symbol} - {market.address}")
+        
+        print("\n" + "="*50)
+        
+        # Get specific market information
+        market = await client.info.get_market(BTC_USD_CLOB)
+        print(f"Market: {market.base.symbol}/{market.quote.symbol}")
+        print(f"Address: {market.address}")
+        print(f"Market Type: {market.market_type}")
+        print(f"Base Token: {market.base.symbol} ({market.base.address})")
+        print(f"Quote Token: {market.quote.symbol} ({market.quote.address})")
+        
+        # Get orderbook
+        orderbook = await client.info.get_orderbook(BTC_USD_CLOB)
+        print(f"\nOrderbook:")
+        print(f"Best bid: {orderbook.bids[0] if orderbook.bids else 'None'}")
+        print(f"Best ask: {orderbook.asks[0] if orderbook.asks else 'None'}")
+        
+        # Get recent trades
+        trades = await client.info.get_trades(BTC_USD_CLOB)
+        print(f"\nRecent trades ({len(trades)} trades):")
+        for trade in trades[:5]:  # Show first 5 trades
+            print(f"  Price: {trade.price}, Size: {trade.size}, Side: {trade.side}")
+        
+        # Get market stats/ticker
+        ticker = await client.info.get_market(BTC_USD_CLOB)
+        print(f"\nMarket Stats:")
+        print(f"  24h Volume: {ticker.get('volume24HrUsd', 'N/A')}")
+        print(f"  24h Change: {ticker.get('priceChange24Hr', 'N/A')}")
+        print(f"  Last Price: {ticker.get('priceUsd', 'N/A')}")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/show_open_orders.py
+++ b/examples/show_open_orders.py
@@ -9,8 +9,9 @@ from eth_utils.address import to_checksum_address
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from gte_py.models import Market
+from examples.constants import BTC_USD_CLOB
 
-MARKET_ADDRESS = to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
+MARKET_ADDRESS = BTC_USD_CLOB
 
 
 async def display_market_info(client: GTEClient, market_address: ChecksumAddress) -> Market:

--- a/examples/subscribe_trades.py
+++ b/examples/subscribe_trades.py
@@ -3,13 +3,14 @@ import sys
 sys.path.append(".")
 import asyncio
 from typing import Any
-from eth_utils.address import to_checksum_address
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 
+from examples.constants import BTC_USD_CLOB
+
 # BTC/USD market address
-MARKET_ADDRESS = to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
+MARKET_ADDRESS = BTC_USD_CLOB
 
 
 async def handle_trade_data(raw_data: dict[str, Any]):

--- a/examples/uniswap_swap.py
+++ b/examples/uniswap_swap.py
@@ -1,0 +1,52 @@
+"""example of swapping towken on AMM"""
+from decimal import Decimal
+import sys
+sys.path.append(".")
+import asyncio
+from eth_utils.address import to_checksum_address
+
+from gte_py.clients import GTEClient
+from gte_py.configs import TESTNET_CONFIG
+from examples.utils import WALLET_PRIVATE_KEY
+
+# BTC/ETH AMM
+MARKET_ADDRESS = to_checksum_address("0x6bba3ff4b359392decd0b77239b7e795269fb550")
+
+async def main():
+    config = TESTNET_CONFIG
+        
+    async with GTEClient(config=config, wallet_private_key=WALLET_PRIVATE_KEY) as client:
+        
+        market = await client.info.get_market(MARKET_ADDRESS)
+        print(market.quote)
+        amount_in = Decimal('0.01')
+        
+        # get quote for amount in
+        quote = await client.execution.get_swap_quote(
+            token_in=market.base,
+            token_out=market.quote,
+            amount_in=amount_in,
+        )
+        print(quote)
+        
+        # use quote for exact amount out
+        txn = await client.execution.swap_tokens_for_exact_output(
+            token_in=market.base,
+            token_out=market.quote,
+            amount_out=quote[0],
+            slippage_tolerance=0.001,
+        )
+        print(txn)
+        
+        # swap tokens
+        txn = await client.execution.swap_tokens(
+            token_in=market.base,
+            token_out=market.quote,
+            amount_in=amount_in,
+            slippage_tolerance=0.05,
+        )
+        print(txn)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/uniswap_swap.py
+++ b/examples/uniswap_swap.py
@@ -3,14 +3,14 @@ from decimal import Decimal
 import sys
 sys.path.append(".")
 import asyncio
-from eth_utils.address import to_checksum_address
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from examples.utils import WALLET_PRIVATE_KEY
+from examples.constants import BTC_ETH_AMM
 
 # BTC/ETH AMM
-MARKET_ADDRESS = to_checksum_address("0x6bba3ff4b359392decd0b77239b7e795269fb550")
+MARKET_ADDRESS = BTC_ETH_AMM
 
 async def main():
     config = TESTNET_CONFIG

--- a/examples/watch_clob_events.py
+++ b/examples/watch_clob_events.py
@@ -5,16 +5,15 @@ import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any
-from eth_utils.address import to_checksum_address
 from web3 import AsyncWeb3
-from gte_py.api.chain.clob import ICLOB
 from gte_py.api.chain.event_source import EventStream
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from examples.utils import WALLET_PRIVATE_KEY, WALLET_ADDRESS, print_separator
+from examples.constants import BTC_USD_CLOB
 
 # BTC/USD market address
-MARKET_ADDRESS = to_checksum_address("0x0F3642714B9516e3d17a936bAced4de47A6FFa5F")
+MARKET_ADDRESS = BTC_USD_CLOB
 
 
 def handle_limit_order(event):

--- a/examples/watch_orderbook.py
+++ b/examples/watch_orderbook.py
@@ -13,8 +13,10 @@ from rich.console import Console
 from rich.table import Table
 from web3 import AsyncWeb3
 
+from examples.constants import BTC_USD_CLOB
+
 # BTC/USD CLOB
-MARKET_ADDRESS = "0x0F3642714B9516e3d17a936bAced4de47A6FFa5F"
+MARKET_ADDRESS = BTC_USD_CLOB
 
 # Initialize console for rich text output
 console = Console()

--- a/examples/withdraw_tokens.py
+++ b/examples/withdraw_tokens.py
@@ -2,14 +2,12 @@
 import sys
 sys.path.append(".")
 import asyncio
-from eth_typing import ChecksumAddress
-from eth_utils.address import to_checksum_address
 
 from gte_py.clients import GTEClient
 from gte_py.configs import TESTNET_CONFIG
 from examples.utils import WALLET_ADDRESS, WALLET_PRIVATE_KEY
 
-BTC_ADDRESS: ChecksumAddress = to_checksum_address("0x7f11aa697e05b75600354ac9acf8bb209225e932")
+from examples.constants import BTC_ADDRESS
 
 def print_separator(title: str) -> None:
     """Print a section separator."""

--- a/src/gte_py/clients/__init__.py
+++ b/src/gte_py/clients/__init__.py
@@ -58,8 +58,7 @@ class GTEClient:
                 web3=self._web3,
                 account=self._account,
                 gte_router_address=config.router_address,
-                weth_address=config.weth_address,
-                clob_manager_address=config.clob_manager_address,
+                info=self.info,
             )
         
         self.connected = False
@@ -79,6 +78,9 @@ class GTEClient:
     async def disconnect(self):
         if not self.connected:
             return
+        
+        if self._execution:
+            await self._execution._scheduler.stop()
         
         await self.info.unsubscribe_all()
         await self.rest.disconnect()

--- a/src/gte_py/clients/execution/__init__.py
+++ b/src/gte_py/clients/execution/__init__.py
@@ -2,20 +2,23 @@
 
 import logging
 from typing import Optional, Tuple, Any, List
+import time
+from decimal import Decimal
 
 from eth_typing import ChecksumAddress
 from eth_account.signers.local import LocalAccount
+from hexbytes import HexBytes
 from typing_extensions import Unpack
 from web3 import AsyncWeb3
-from web3.types import TxParams
+from web3.types import TxParams, Wei
 
-from gte_py.api.chain.clob_client import CLOBClient
-from gte_py.api.chain.token_client import TokenClient
-from gte_py.api.chain.events import OrderAmendedEvent, OrderCanceledEvent, FillOrderProcessedEvent, LimitOrderProcessedEvent, parse_fill_order_processed, parse_limit_order_processed, parse_deposit, parse_order_canceled, parse_withdraw, parse_order_amended
-from gte_py.api.chain.structs import ICLOBAmendArgs, OrderSide, Settlement, LimitOrderType, FillOrderType, OperatorRole, ICLOBPostFillOrderArgs, ICLOBPostLimitOrderArgs, ICLOBCancelArgs
+from gte_py.clients.info import InfoClient
+from gte_py.api.chain.chain_client import ChainClient
+from gte_py.api.chain.events import OrderAmendedEvent, OrderCanceledEvent, FillOrderProcessedEvent, LimitOrderProcessedEvent
+from gte_py.api.chain.structs import AmendArgs, OrderSide, Settlement, LimitOrderType, FillOrderType, OperatorRole, PostFillOrderArgs, PostLimitOrderArgs, CancelArgs
 from gte_py.api.chain.utils import TypedContractFunction, BoundedNonceTxScheduler
-from gte_py.models import Market, Order, OrderStatus, TimeInForce
-from gte_py.api.chain.erc20 import ERC20
+from gte_py.models import Market, Order, OrderStatus, TimeInForce, Token
+from gte_py.api.chain.erc20 import Erc20
 
 logger = logging.getLogger(__name__)
 
@@ -28,51 +31,48 @@ class ExecutionClient:
             web3: AsyncWeb3,
             account: LocalAccount,
             gte_router_address: ChecksumAddress,
-            weth_address: ChecksumAddress,
-            clob_manager_address: ChecksumAddress,
+            info: InfoClient,
     ):
         """
         Initialize the execution client.
 
         Args:
             web3: AsyncWeb3 instance for on-chain interactions
-            main_account: Address to send transactions from
+            account: Address to send transactions from
             gte_router_address: Address of the GTE router
+            clob_manager_address: Address of the CLOB manager
         """
         self._web3 = web3
         self._account = account
-        self._gte_router_address = gte_router_address
-        self._clob_client = CLOBClient(web3, gte_router_address)
-        self._token_client = TokenClient(web3)
-        self._weth_address = weth_address
-        self._clob_factory = None
-        self._clob_manager_address = clob_manager_address
+        self._chain_client = ChainClient(web3, gte_router_address)
         self._scheduler = BoundedNonceTxScheduler(
             web3=self._web3,
             account=self._account,
         )
+        self._info = info
         
-        # Cache for approved tokens to avoid repeated approval checks
-        self._approved_tokens: set[ChecksumAddress] = set()
+        # Cache for approved clob tokens
+        self._approved_clob_tokens: set[ChecksumAddress] = set()
+        
+        # Cache for approved swap tokens
+        self._approved_swap_tokens: set[ChecksumAddress] = set()
+        
+        # Cache for approved launchpad tokens
+        self._approved_launchpad_tokens: set[ChecksumAddress] = set()
         
         # Maximum approval amount (2^256 - 1)
         self._max_approval = 2**256 - 1
-        
-        # Cache for price limits to avoid repeated network calls
-        self._price_cache: dict[tuple[ChecksumAddress, OrderSide, float], tuple[int, float]] = {}
 
     async def init(self):
-        """Initialize the CLOB client."""
-        await self._clob_client.init()
-        self._clob_factory = self._clob_client.get_factory_address()
+        """Initialize the chain client."""
+        await self._chain_client.init()
         await self._scheduler.start()
 
     # ================= DEPOSIT/WITHDRAW OPERATIONS =================
     
     async def _ensure_approval(
         self,
-        amount: int,
-        token: ERC20,
+        token: Erc20,
         **kwargs,
     ):
         """
@@ -82,21 +82,548 @@ class ExecutionClient:
         token_address = token.address
         
         # Check if we've already approved this token
-        if token_address in self._approved_tokens:
+        if token_address in self._approved_clob_tokens:
+            return
+        
+        # check if allowance is already set
+        allowance = await token.allowance(owner=self._account.address, spender=self._chain_client.clob_manager_address)
+        if allowance >= self._max_approval // 2:
+            self._approved_clob_tokens.add(token_address)
             return
         
         # Need to approve - use infinite approval
-        _ = await self._scheduler.send_wait(token.approve(spender=self._clob_manager_address, amount=self._max_approval, **kwargs))
+        _ = await self._scheduler.send(token.approve(spender=self._chain_client.clob_manager_address, value=self._max_approval, **kwargs))
         
         # Cache the token as approved
-        self._approved_tokens.add(token_address)
+        self._approved_clob_tokens.add(token_address)
 
-    def _adjust_amount(self, market: Market, amount, amount_is_raw: bool, amount_is_base: bool) -> int:
-        if amount_is_raw:
-            return amount
-        if amount_is_base:
+    async def _ensure_swap_approval(
+        self,
+        token: Erc20,
+        **kwargs,
+    ):
+        """
+        Ensure the token is approved for swap operations.
+        Uses infinite approvals (2^256 - 1) and caches approved tokens.
+        """ 
+        token_address = token.address
+        
+        # Check if we've already approved this token for swaps
+        if token_address in self._approved_swap_tokens:
+            return
+        
+        # check if allowance is already set
+        allowance = await token.allowance(owner=self._account.address, spender=self._chain_client.univ2_router_address)
+        if allowance >= self._max_approval // 2:
+            self._approved_swap_tokens.add(token_address)
+            return
+        
+        # Need to approve - use infinite approval
+        _ = await self._scheduler.send(token.approve(spender=self._chain_client.univ2_router_address, value=self._max_approval, **kwargs))
+        
+        # Cache the token as approved for swaps
+        self._approved_swap_tokens.add(token_address)
+
+    # ================= LAUNCHPAD OPERATIONS =================
+    
+    async def _ensure_launchpad_approval(
+        self,
+        token: Erc20,
+        **kwargs,
+    ):
+        """
+        Ensure the token is approved for launchpad operations.
+        Uses infinite approvals (2^256 - 1) and caches approved tokens.
+        """ 
+        token_address = token.address
+        
+        # Check if we've already approved this token for launchpad
+        if token_address in self._approved_launchpad_tokens:
+            return
+        
+        # check if allowance is already set
+        allowance = await token.allowance(owner=self._account.address, spender=self._chain_client.launchpad_address)
+        if allowance >= self._max_approval // 2:
+            self._approved_launchpad_tokens.add(token_address)
+            return
+        
+        # Standard DeFi pattern: approve the launchpad contract to spend this token
+        # This allows launchpad.transferFrom(user, launchpad, amount) to work
+        _ = await self._scheduler.send(token.approve(
+            spender=self._chain_client.launchpad_address, 
+            value=self._max_approval, 
+            **kwargs
+        ))
+        
+        # Cache the token as approved
+        self._approved_launchpad_tokens.add(token_address)
+        
+        logger.debug(f"Approved {token_address} for launchpad spending by {self._chain_client.launchpad_address}")
+
+    async def launchpad_buy_exact_quote(
+        self,
+        launch_token: Token,
+        quote_token: Token,
+        quote_amount_in: Decimal,
+        slippage_tolerance: float = 0.01,
+        **kwargs: Unpack[TxParams],
+    ):
+        """
+        Buy launch tokens by spending an exact amount of quote tokens.
+        
+        Args:
+            launch_token: Launch token to buy
+            quote_token: Quote token to spend
+            quote_amount_in: Exact amount of quote tokens to spend (in decimal units)
+            slippage_tolerance: Slippage tolerance (0.01 = 1%)
+            **kwargs: Additional transaction parameters
+            
+        Returns:
+            Transaction receipt from the buy operation
+        """
+        # Convert decimal amount to atomic units
+        quote_amount_atomic = quote_token.convert_quantity_to_amount(quote_amount_in)
+        
+        # Get quote for how much base we'll receive
+        expected_base_out = await self._chain_client.launchpad.quote_base_for_quote(
+            token=launch_token.address,
+            quote_amount=quote_amount_atomic,
+            is_buy=True
+        )
+        
+        # Apply slippage to minimum base amount out
+        min_base_out = int(expected_base_out * (1 - slippage_tolerance))
+        
+        # Ensure approval for quote token
+        quote_token_contract = self._chain_client.get_erc20(quote_token.address)
+        await self._ensure_launchpad_approval(
+            token=quote_token_contract,
+            **kwargs,
+        )
+        
+        logger.info(f"Buying {launch_token.symbol} with exactly {quote_amount_in} {quote_token.symbol}")
+
+        tx = self._chain_client.launchpad.buy(
+            account=self._account.address,
+            token=launch_token.address,
+            recipient=self._account.address,
+            amount_out_base=min_base_out,
+            max_amount_in_quote=quote_amount_atomic,
+            **kwargs,
+        )
+        
+        return await self._scheduler.send(tx)
+
+    async def launchpad_sell_exact_base(
+        self,
+        launch_token: Token,
+        quote_token: Token,
+        base_amount_in: Decimal,
+        slippage_tolerance: float = 0.01,
+        **kwargs: Unpack[TxParams],
+    ):
+        """
+        Sell an exact amount of launch tokens for quote tokens.
+        
+        Args:
+            launch_token: Launch token to sell
+            quote_token: Quote token to receive
+            base_amount_in: Exact amount of launch tokens to sell (in decimal units)
+            slippage_tolerance: Slippage tolerance (0.01 = 1%)
+            **kwargs: Additional transaction parameters
+            
+        Returns:
+            Transaction receipt from the sell operation
+        """
+        # Convert decimal amount to atomic units
+        base_amount_atomic = launch_token.convert_quantity_to_amount(base_amount_in)
+        
+        # Get quote for how much quote we'll receive
+        expected_quote_out = await self._chain_client.launchpad.quote_quote_for_base(
+            token=launch_token.address,
+            base_amount=base_amount_atomic,
+            is_buy=False
+        )
+        
+        # Apply slippage to minimum quote amount out
+        min_quote_out = int(expected_quote_out * (1 - slippage_tolerance))
+        
+        # Ensure approval for launch token
+        launch_token_contract = self._chain_client.get_erc20(launch_token.address)
+        await self._ensure_launchpad_approval(
+            token=launch_token_contract,
+            **kwargs,
+        )
+        
+        logger.info(f"Selling exactly {base_amount_in} {launch_token.symbol} for {quote_token.symbol}")
+
+        tx = self._chain_client.launchpad.sell(
+            account=self._account.address,
+            token=launch_token.address,
+            recipient=self._account.address,
+            amount_in_base=base_amount_atomic,
+            min_amount_out_quote=min_quote_out,
+            **kwargs,
+        )
+        
+        return await self._scheduler.send(tx)
+
+    async def get_launchpad_quote_buy(
+        self,
+        launch_token: Token,
+        quote_token: Token,
+        quote_amount: Decimal,
+    ) -> tuple[Decimal, Decimal]:
+        """
+        Get a quote for buying launch tokens with quote tokens.
+        
+        Args:
+            launch_token: Launch token to buy
+            quote_token: Quote token to spend
+            quote_amount: Amount of quote tokens to spend (in decimal units)
+            
+        Returns:
+            Tuple of (base_tokens_received, effective_price_per_base)
+        """
+        quote_amount_atomic = quote_token.convert_quantity_to_amount(quote_amount)
+        
+        # Get quote from launchpad
+        base_amount_atomic = await self._chain_client.launchpad.quote_base_for_quote(
+            token=launch_token.address,
+            quote_amount=quote_amount_atomic,
+            is_buy=True
+        )
+        
+        # Convert back to decimal units
+        base_amount = launch_token.convert_amount_to_quantity(base_amount_atomic)
+        
+        # Calculate effective price (quote per base)
+        effective_price = quote_amount / base_amount if base_amount > 0 else Decimal('0')
+        
+        return base_amount, effective_price
+
+    async def get_launchpad_quote_sell(
+        self,
+        launch_token: Token,
+        quote_token: Token,
+        base_amount: Decimal,
+    ) -> tuple[Decimal, Decimal]:
+        """
+        Get a quote for selling launch tokens for quote tokens.
+        
+        Args:
+            launch_token: Launch token to sell
+            quote_token: Quote token to receive
+            base_amount: Amount of launch tokens to sell (in decimal units)
+            
+        Returns:
+            Tuple of (quote_tokens_received, effective_price_per_base)
+        """
+        base_amount_atomic = launch_token.convert_quantity_to_amount(base_amount)
+        
+        # Get quote from launchpad
+        quote_amount_atomic = await self._chain_client.launchpad.quote_quote_for_base(
+            token=launch_token.address,
+            base_amount=base_amount_atomic,
+            is_buy=False
+        )
+
+        # Convert back to decimal units
+        quote_amount = quote_token.convert_amount_to_quantity(quote_amount_atomic)
+        
+        # Calculate effective price (quote per base)
+        effective_price = quote_amount / base_amount if base_amount > 0 else Decimal('0')
+        
+        return quote_amount, effective_price
+    
+    # ================= EXISTING METHODS CONTINUE... =================
+
+    def _convert_amount_to_atomic(self, market: Market, amount: Decimal, is_base: bool) -> int:
+        """Convert decimal amount to atomic units based on token type."""
+        if is_base:
             return market.base.convert_quantity_to_amount(amount)
         return market.quote.convert_quantity_to_amount(amount)
+
+    # ================= TOKEN SWAP OPERATIONS =================
+    
+    def _get_swap_function(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_in_atomic: int,
+        amount_out_min: int,
+        path: list[ChecksumAddress],
+        deadline: int,
+        **kwargs,
+    ) -> TypedContractFunction[Any]:
+        """
+        Get the appropriate swap function based on whether WETH is involved.
+        
+        Args:
+            token_in: Input token
+            token_out: Output token
+            amount_in_atomic: Input amount in atomic units
+            amount_out_min: Minimum output amount
+            path: Swap path
+            deadline: Transaction deadline
+            **kwargs: Additional transaction parameters
+            
+        Returns:
+            TypedContractFunction for the appropriate swap method
+        """
+        is_eth_in = token_in.address == self._chain_client.weth_address
+        is_eth_out = token_out.address == self._chain_client.weth_address
+        
+        if is_eth_in and not is_eth_out:
+            # ETH -> Token: use swapExactETHForTokens
+            return self._chain_client.univ2_router.swap_exact_eth_for_tokens(
+                amount_out_min=amount_out_min,
+                path=path,
+                to_=self._account.address,
+                deadline=deadline,
+                value=amount_in_atomic,  # ETH value sent with transaction
+                **kwargs,
+            )
+        elif not is_eth_in and is_eth_out:
+            # Token -> ETH: use swapExactTokensForETH
+            return self._chain_client.univ2_router.swap_exact_tokens_for_eth(
+                amount_in=amount_in_atomic,
+                amount_out_min=amount_out_min,
+                path=path,
+                to_=self._account.address,
+                deadline=deadline,
+                **kwargs,
+            )
+        else:
+            # Token -> Token: use swapExactTokensForTokens
+            return self._chain_client.univ2_router.swap_exact_tokens_for_tokens(
+                amount_in=amount_in_atomic,
+                amount_out_min=amount_out_min,
+                path=path,
+                to_=self._account.address,
+                deadline=deadline,
+                **kwargs,
+            )
+
+    async def swap_tokens(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_in: Decimal,
+        slippage_tolerance: float = 0.01,
+        deadline_seconds: int = 1200,
+        **kwargs: Unpack[TxParams],
+    ):
+        """
+        Swap tokens using UniswapV2 through the GTE Router.
+        
+        Args:
+            token_in: Input token object with decimals
+            token_out: Output token object with decimals
+            amount_in: Amount to swap (in decimal units, e.g., Decimal('1.5'))
+            slippage_tolerance: Slippage tolerance (0.01 = 1%)
+            deadline_seconds: Seconds from now until transaction deadline
+            **kwargs: Additional transaction parameters
+             
+        Returns:
+            Transaction receipt from the swap
+        """
+        # Convert decimal amount to atomic units
+        amount_in_atomic = token_in.convert_quantity_to_amount(amount_in)
+        
+        # Create swap path
+        path = [token_in.address, token_out.address]
+        
+        # Get expected output amount
+        amounts_out = await self._chain_client.univ2_router.get_amounts_out(amount_in_atomic, path)
+        expected_out = amounts_out[-1]  # Output amount is the last element
+        
+        # Calculate minimum output with slippage
+        amount_out_min = int(expected_out * (1 - slippage_tolerance))
+        
+        # Calculate deadline
+        deadline = int(time.time()) + deadline_seconds
+        
+        # Only approve if input token is not ETH/WETH (for ETH swaps, no approval needed)
+        if token_in.address != self._chain_client.weth_address:
+            token_in_contract = self._chain_client.get_erc20(token_in.address)
+            await self._ensure_swap_approval(
+                token=token_in_contract,
+                **kwargs,
+            )
+        
+        logger.info(f"Swapping {amount_in} {token_in.symbol} for {token_out.symbol}")
+
+        # Get the appropriate swap function
+        swap_tx = self._get_swap_function(
+            token_in=token_in,
+            token_out=token_out,
+            amount_in_atomic=amount_in_atomic,
+            amount_out_min=amount_out_min,
+            path=path,
+            deadline=deadline,
+            **kwargs,
+        )
+        
+        return await self._scheduler.send(swap_tx)
+
+    def _get_swap_for_exact_function(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_out_atomic: int,
+        amount_in_max: int,
+        path: list[ChecksumAddress],
+        deadline: int,
+        **kwargs,
+    ) -> TypedContractFunction[Any]:
+        """
+        Get the appropriate swap function for exact output based on whether WETH is involved.
+        
+        Args:
+            token_in: Input token
+            token_out: Output token
+            amount_out_atomic: Exact output amount in atomic units
+            amount_in_max: Maximum input amount
+            path: Swap path
+            deadline: Transaction deadline
+            **kwargs: Additional transaction parameters
+            
+        Returns:
+            TypedContractFunction for the appropriate swap method
+        """
+        is_eth_in = token_in.address == self._chain_client.weth_address
+        is_eth_out = token_out.address == self._chain_client.weth_address
+        
+        if is_eth_in and not is_eth_out:
+            # ETH -> Token: use swapETHForExactTokens
+            return self._chain_client.univ2_router.swap_eth_for_exact_tokens(
+                amount_out=amount_out_atomic,
+                path=path,
+                to=self._account.address,
+                deadline=deadline,
+                value=amount_in_max,  # ETH value sent with transaction
+                **kwargs,
+            )
+        elif not is_eth_in and is_eth_out:
+            # Token -> ETH: use swapTokensForExactETH
+            return self._chain_client.univ2_router.swap_tokens_for_exact_eth(
+                amount_out=amount_out_atomic,
+                amount_in_max=amount_in_max,
+                path=path,
+                to=self._account.address,
+                deadline=deadline,
+                **kwargs,
+            )
+        else:
+            # Token -> Token: use swapTokensForExactTokens
+            return self._chain_client.univ2_router.swap_tokens_for_exact_tokens(
+                amount_out=amount_out_atomic,
+                amount_in_max=amount_in_max,
+                path=path,
+                to=self._account.address,
+                deadline=deadline,
+                **kwargs,
+            )
+
+    async def swap_tokens_for_exact_output(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_out: Decimal,
+        slippage_tolerance: float = 0.01,
+        deadline_seconds: int = 1200,
+        **kwargs: Unpack[TxParams],
+    ):
+        """
+        Swap tokens for an exact output amount using UniswapV2 through the GTE Router.
+        
+        Args:
+            token_in: Input token object with decimals
+            token_out: Output token object with decimals
+            amount_out: Exact amount to receive (in decimal units)
+            slippage_tolerance: Slippage tolerance (0.01 = 1%)
+            deadline_seconds: Seconds from now until transaction deadline
+            **kwargs: Additional transaction parameters
+            
+        Returns:
+            Transaction receipt from the swap
+        """
+        # Convert decimal amount to atomic units
+        amount_out_atomic = token_out.convert_quantity_to_amount(amount_out)
+        
+        # Create swap path
+        path = [token_in.address, token_out.address]
+        
+        # Get required input amount
+        amounts_in = await self._chain_client.univ2_router.get_amounts_in(amount_out_atomic, path)
+        expected_in = amounts_in[0]  # Input amount is the first element
+        
+        # Calculate maximum input with slippage
+        amount_in_max = int(expected_in * (1 + slippage_tolerance))
+        
+        # Calculate deadline
+        deadline = int(time.time()) + deadline_seconds
+        
+        # Only approve if input token is not ETH/WETH (for ETH swaps, no approval needed)
+        if token_in.address != self._chain_client.weth_address:
+            token_in_contract = self._chain_client.get_erc20(token_in.address)
+            await self._ensure_swap_approval(
+                token=token_in_contract,
+                **kwargs,
+            )
+        
+        logger.info(f"Swapping {token_in.symbol} for exactly {amount_out} {token_out.symbol}")
+
+        # Get the appropriate swap function
+        swap_tx = self._get_swap_for_exact_function(
+            token_in=token_in,
+            token_out=token_out,
+            amount_out_atomic=amount_out_atomic,
+            amount_in_max=amount_in_max,
+            path=path,
+            deadline=deadline,
+            **kwargs,
+        )
+        
+        return await self._scheduler.send(swap_tx)
+
+    async def get_swap_quote(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_in: Decimal,
+    ) -> tuple[Decimal, Decimal]:
+        """
+        Get a quote for swapping tokens.
+        
+        Args:
+            token_in: Input token object with decimals
+            token_out: Output token object with decimals
+            amount_in: Amount to swap (in decimal units)
+            
+        Returns:
+            Tuple of (expected_output_amount, effective_price)
+        """
+        # Convert decimal amount to atomic units
+        amount_in_atomic = token_in.convert_quantity_to_amount(amount_in)
+        
+        # Create swap path
+        path = [token_in.address, token_out.address]
+        
+        # Get expected output amount
+        amounts_out = await self._chain_client.univ2_router.get_amounts_out(amount_in_atomic, path)
+        expected_out_atomic = amounts_out[1]
+        
+        # Convert back to decimal units
+        expected_out = token_out.convert_amount_to_quantity(expected_out_atomic)
+        
+        # Calculate effective price
+        effective_price = expected_out / amount_in if amount_in > 0 else Decimal('0')
+        
+        return expected_out, effective_price
+
+    # ================= EXISTING METHODS CONTINUE... =================
 
     async def deposit(
             self, token_address: ChecksumAddress, amount: int, **kwargs: Unpack[TxParams]
@@ -112,25 +639,20 @@ class ExecutionClient:
         Returns:
             Transaction result from the deposit operation
         """
-        clob_factory = self._clob_client.clob_factory
-        if not clob_factory:
-            await self.init()
-            clob_factory = self._clob_client.clob_factory
-            assert clob_factory is not None, "CLOB factory should be initialized"
 
-        token = self._token_client.get_erc20(token_address)
+        token = self._chain_client.get_erc20(token_address)
         
         # time the approval
-        await self._ensure_approval(amount, token, **kwargs)
+        await self._ensure_approval(token, **kwargs)
 
-        tx = clob_factory.deposit(
+        tx = self._chain_client.clob_manager.deposit(
             account=self._account.address,
             token=token_address,
             amount=amount,
             from_operator=False,
             **kwargs,
-        ).with_event(clob_factory.contract.events.Deposit(), parse_deposit)
-        return await self._scheduler.send_wait(tx)
+        )
+        return await self._scheduler.send(tx)
 
     async def withdraw(
             self, token_address: ChecksumAddress, amount: int, **kwargs: Unpack[TxParams]
@@ -146,32 +668,27 @@ class ExecutionClient:
         Returns:
             Transaction result from the withdrawal transaction
         """
-        clob_factory = self._clob_client.clob_factory
-        if not clob_factory:
-            await self.init()
-            clob_factory = self._clob_client.clob_factory
-            assert clob_factory is not None, "CLOB factory should be initialized"
-
-        tx = clob_factory.withdraw(
+        tx = self._chain_client.clob_manager.withdraw(
             account=self._account.address, token=token_address, amount=amount, to_operator=False, **kwargs
-        ).with_event(clob_factory.contract.events.Withdraw(), parse_withdraw)
+        )
         
-        return await self._scheduler.send_wait(tx)
+        return await self._scheduler.send(tx)
 
     async def get_token_balance(self, token_address: ChecksumAddress) -> int:
         """
         Get the balance of a token in the wallet.
         """
-        return await self._token_client.get_erc20(token_address).balance_of(self._account.address)
+        return await self._chain_client.get_erc20(token_address).balance_of(self._account.address)
     
-    async def get_weth_balance(self) -> int:
+    async def get_weth_balance(self) -> Decimal:
         """
         Get the balance of WETH in the wallet.
         """
-        return await self.get_token_balance(self._weth_address)
+        weth_token = Token(address=self._chain_client.weth_address, decimals=18, name="Wrapped Ether", symbol="WETH", total_supply=None)
+        return weth_token.convert_amount_to_quantity(await self.get_token_balance(self._chain_client.weth_address))
 
     async def wrap_eth(
-            self, amount: int, **kwargs: Unpack[TxParams]
+            self, amount: Decimal, **kwargs: Unpack[TxParams]
     ):
         """
         Wrap ETH to WETH.
@@ -181,14 +698,19 @@ class ExecutionClient:
             **kwargs: Additional transaction parameters
 
         Returns:
-            Transaction result from the wrap operation
+            Transaction hash from the wrap operation
         """
-        weth = self._token_client.get_weth(self._weth_address)
-        tx = weth.deposit_eth(amount, **kwargs).with_event(weth.contract.events.Deposit())
-        return await self._scheduler.send_wait(tx)
+        weth_token = Token(address=self._chain_client.weth_address, decimals=18, name="Wrapped Ether", symbol="WETH", total_supply=None)
+        amount_wei = weth_token.convert_quantity_to_amount(amount)
+        weth = self._chain_client.weth
+
+        kwargs['value'] = Wei(amount_wei)
+        
+        tx = weth.deposit(**kwargs)
+        return await self._scheduler.send(tx)
 
     async def unwrap_eth(
-            self, amount: int, **kwargs: Unpack[TxParams]
+            self, amount: Decimal, **kwargs: Unpack[TxParams]
     ):
         """
         Unwrap WETH to ETH.
@@ -198,11 +720,13 @@ class ExecutionClient:
             **kwargs: Additional transaction parameters
 
         Returns:
-            Transaction result from the unwrap operation
+            Transaction hash from the unwrap operation
         """
-        weth = self._token_client.get_weth(self._weth_address)
-        tx = weth.withdraw_eth(amount, **kwargs).with_event(weth.contract.events.Withdrawal())
-        return await self._scheduler.send_wait(tx)
+        weth_token = Token(address=self._chain_client.weth_address, decimals=18, name="Wrapped Ether", symbol="WETH", total_supply=None)
+        amount_wei = weth_token.convert_quantity_to_amount(amount)
+        weth = self._chain_client.weth
+        tx = weth.withdraw(value_=amount_wei, **kwargs)
+        return await self._scheduler.send(tx)
 
     # ================= APPROVE OPERATIONS =================
 
@@ -229,7 +753,7 @@ class ExecutionClient:
             **kwargs: Additional transaction parameters
 
         Returns:
-            Transaction result from the approve_operator operation
+            Transaction hash from the approve_operator operation
         """
         if OperatorRole.WITHDRAW in roles and not unsafe_withdraw:
             raise ValueError("Unsafe withdraw must be enabled to approve withdraw role")
@@ -239,14 +763,8 @@ class ExecutionClient:
         roles_int = self._encode_rules(roles)
         logger.info(f"Approving operator {operator_address} for account {self._account.address} with roles {roles}")
 
-        # The clob_factory is actually the clob_manager
-        clob_factory = self._clob_client.clob_factory
-        if not clob_factory:
-            await self.init()
-            clob_factory = self._clob_client.clob_factory
-            assert clob_factory is not None, "CLOB factory should be initialized"
 
-        return await self._scheduler.send_wait(clob_factory.approve_operator(
+        return await self._scheduler.send(self._chain_client.clob_manager.approve_operator(
             operator=operator_address,
             roles=roles_int,
             **kwargs
@@ -264,28 +782,29 @@ class ExecutionClient:
             **kwargs: Additional transaction parameters
 
         Returns:
-            Transaction result from the disapprove_operator operation
+            Transaction hash from the disapprove_operator operation
         """
         roles_int = self._encode_rules(roles)
         logger.info(f"Disapproving operator {operator_address} for account {self._account.address} with roles {roles}")
-        
-        # The clob_factory is actually the clob_manager
-        clob_factory = self._clob_client.clob_factory
-        if not clob_factory:
-            await self.init()
-            clob_factory = self._clob_client.clob_factory
-            assert clob_factory is not None, "CLOB factory should be initialized"
 
-        return await self._scheduler.send_wait(clob_factory.disapprove_operator(
+        return await self._scheduler.send(self._chain_client.clob_manager.disapprove_operator(
             operator=operator_address,
             roles=roles_int,
             **kwargs
         ))
 
-    # ================= ROUTER-BASED ORDER OPERATIONS =================
-    # These methods use the router contract for consistency, but note that router calls
-    # don't emit events directly - they route to CLOB contracts which emit the events.
+    # ================= ORDER OPERATIONS =================
 
+    async def get_tob(self, market: Market) -> tuple[Decimal, Decimal]:
+        """
+        Get the top of book for a market.
+        Returns:
+            Tuple of (best bid price, best ask price)
+        """
+        clob = self._chain_client.get_clob(market.address)
+        best_bid, best_ask = await clob.get_tob()
+        return market.quote.convert_amount_to_quantity(best_bid), market.quote.convert_amount_to_quantity(best_ask)
+    
     def place_limit_order_tx(
             self,
             market_address: ChecksumAddress,
@@ -316,8 +835,6 @@ class ExecutionClient:
         Returns:
             TypedContractFunction that can be used to execute the transaction
         """
-        router = self._clob_client.get_router()
-        clob = self._clob_client.get_clob(market_address)
 
         # For IOC and FOK orders, we use the fill order API
         if time_in_force in [TimeInForce.IOC, TimeInForce.FOK]:
@@ -329,7 +846,7 @@ class ExecutionClient:
                 raise ValueError(f"Unknown time_in_force: {time_in_force}")
 
             # Create post fill order args using NamedTuple
-            args = ICLOBPostFillOrderArgs(
+            args = PostFillOrderArgs(
                 amount,
                 price,
                 side.value,
@@ -339,7 +856,7 @@ class ExecutionClient:
             )
 
             # Return the router transaction
-            return router.clob_post_fill_order(clob=market_address, args=args, **kwargs).with_event(clob.contract.events.FillOrderProcessed(), parse_fill_order_processed)
+            return self._chain_client.router.clob_post_fill_order(clob=market_address, args=args, **kwargs)
         else:
             if time_in_force == TimeInForce.GTC:
                 tif = LimitOrderType.GOOD_TILL_CANCELLED
@@ -349,7 +866,7 @@ class ExecutionClient:
                 raise ValueError(f"Unknown time_in_force: {time_in_force}")
             
             # Create post limit order args using NamedTuple
-            args = ICLOBPostLimitOrderArgs(
+            args = PostLimitOrderArgs(
                 amount,
                 price,
                 0,  # cancelTimestamp - no expiration
@@ -360,66 +877,60 @@ class ExecutionClient:
             )
 
             # Return the router transaction
-            return router.clob_post_limit_order(clob=market_address, args=args, **kwargs).with_event(clob.contract.events.LimitOrderProcessed(), parse_limit_order_processed)
+            return self._chain_client.router.clob_post_limit_order(clob=market_address, args=args, **kwargs)
 
     async def place_limit_order(
             self,
             market: Market,
             side: OrderSide,
-            amount: int | float,
-            price: int | float,
-            amount_is_raw: bool = True,
-            price_is_raw: bool = True,
+            amount: Decimal,
+            price: Decimal,
             time_in_force: TimeInForce = TimeInForce.GTC,
             client_order_id: int = 0,
             settlement: Settlement = Settlement.INSTANT,
+            return_order: bool = False,
             **kwargs: Unpack[TxParams],
-    ) -> LimitOrderProcessedEvent | FillOrderProcessedEvent:
+    ) -> str | dict[str, Any]:
         """
         Place a limit order using the router contract.
         
-        Note: This method returns a transaction receipt since router calls don't emit events.
-        Use place_limit_order_with_events() if you need event-based order tracking.
-
         Args:
             market: Market to place the order on
             side: Order side (BUY or SELL)
-            amount: Order amount
-            amount_is_raw: Whether the amount is in raw units
-            price: Order price
-            price_is_raw: Whether the price is in raw units
+            amount: Order amount in decimal units
+            price: Order price in decimal units
             time_in_force: Time in force (GTC, IOC, FOK)
             client_order_id: Optional client order ID for tracking
             **kwargs: Additional transaction parameters
 
         Returns:
-            Transaction receipt of the placed order
+            Transaction hash of the placed order or Event of the placed order
         """
-        amount = int(market.base.convert_quantity_to_amount(amount) if not amount_is_raw else amount)
-        price = int(market.quote.convert_quantity_to_amount(price) if not price_is_raw else price)
+        amount_atomic = market.base.convert_quantity_to_amount(amount)
+        price_atomic = market.quote.convert_quantity_to_amount(price)
         
-        token, approval_amount = self._compute_approval_requirements(market, side, amount, True, price)
+        token = self._chain_client.get_erc20(market.quote.address) if side == OrderSide.BUY else self._chain_client.get_erc20(market.base.address)
         await self._ensure_approval(
-            amount=approval_amount,
             token=token,
             **kwargs,
         )
-        
-        clob = self._clob_client.get_clob(market.address)
-        
+        clob = self._chain_client.get_clob(market.address)
         tx = self.place_limit_order_tx(
             market_address=market.address,
             side=side,
-            amount=amount,
-            price=price,
+            amount=amount_atomic,
+            price=price_atomic,
             time_in_force=time_in_force,
             client_order_id=client_order_id,
             settlement=settlement,
             **kwargs,
-        ).with_event(clob.contract.events.LimitOrderProcessed(), parse_limit_order_processed)
+        ).with_event(clob.contract.events.LimitOrderProcessed())
         
         # Send the transaction and return the receipt
-        return await self._scheduler.send_wait(tx)
+        if return_order:
+            return await self._scheduler.send_wait(tx)
+        else:
+            return await self._scheduler.send(tx)
 
     def place_market_order_tx(
             self,
@@ -444,10 +955,9 @@ class ExecutionClient:
         Returns:
             TypedContractFunction that can be used to execute the transaction
         """
-        router = self._clob_client.get_router()
 
         # Create post fill order args using named tuple
-        args = ICLOBPostFillOrderArgs(
+        args = PostFillOrderArgs(
             amount,
             price_limit,
             side.value,
@@ -457,13 +967,13 @@ class ExecutionClient:
         )
 
         # Return the router transaction
-        return router.clob_post_fill_order(clob=market.address, args=args, **kwargs)
+        return self._chain_client.router.clob_post_fill_order(clob=market.address, args=args, **kwargs)
 
     async def _get_price_limit(self, market: Market, side: OrderSide, slippage: float = 0.01) -> int:
         """
         Get the price limit for a market order with slippage applied.
         """
-        clob = self._clob_client.get_clob(market.address)
+        clob = self._chain_client.get_clob(market.address)
         highest_bid, lowest_ask = await clob.get_tob()
         
         if side == OrderSide.BUY:
@@ -472,50 +982,23 @@ class ExecutionClient:
         else:
             # For SELL orders, use highest bid with negative slippage
             return int(highest_bid * (1 - slippage))
-    
-    def _compute_approval_requirements(
-            self,
-            market: Market,
-            side: OrderSide,
-            amount: int,
-            amount_is_base: bool,
-            price_limit: int,
-        ):
-        if side == OrderSide.BUY:
-            token = self._token_client.get_erc20(market.quote.address)
-            if amount_is_base:
-                # amount is already in base tokens, so we approve the quote token for the amount * price limit
-                required = amount * market.quote.convert_amount_to_quantity(price_limit)
-            else:
-                # amount is in quote tokens, so we approve the quote token for the amount
-                required = amount
-        else:
-            token = self._token_client.get_erc20(market.base.address)
-            if amount_is_base:
-                # amount is in base tokens, so we approve the base token for the amount
-                required = amount
-            else:
-                # amount is in quote tokens, so we approve the base token for the amount / price limit
-                required = amount // market.quote.convert_amount_to_quantity(price_limit)
-        return token, int(required)
 
     async def place_market_order(
             self,
             market: Market,
             side: OrderSide,
-            amount: int | float,
-            amount_is_raw: bool = True,
+            amount: Decimal,
             amount_is_base: bool = True,
             slippage: float = 0.01,
             **kwargs,
-    ) -> FillOrderProcessedEvent:
+    ):
         """
         Place a market order using the router contract.
 
         Args:
             market: Market to place the order on
             side: Order side (BUY or SELL)
-            amount: Order amount in base tokens if amount_is_base is True, otherwise in quote tokens
+            amount: Order amount in decimal units
             amount_is_base: Whether the amount is in base tokens
             slippage: Slippage percentage for price limit
             **kwargs: Additional transaction parameters
@@ -523,27 +1006,24 @@ class ExecutionClient:
         Returns:
             Transaction receipt of the placed order
         """
-        amount = self._adjust_amount(market, amount, amount_is_raw, amount_is_base)
+        amount_atomic = market.base.convert_quantity_to_amount(amount) if amount_is_base else market.quote.convert_quantity_to_amount(amount)
         price_limit = await self._get_price_limit(market, side, slippage)
-        token, approval_amount = self._compute_approval_requirements(market, side, amount, amount_is_base, price_limit)
+        token = self._chain_client.get_erc20(market.quote.address) if amount_is_base else self._chain_client.get_erc20(market.base.address)
         
         await self._ensure_approval(
-            amount=approval_amount,
             token=token,
             **kwargs,
         )
         
-        clob = self._clob_client.get_clob(market.address)
-        
         tx = self.place_market_order_tx(
             market=market,
             side=side,
-            amount=amount,
+            amount=amount_atomic,
             price_limit=price_limit,
             amount_is_base=amount_is_base,
             **kwargs,
-        ).with_event(clob.contract.events.FillOrderProcessed(), parse_fill_order_processed)
-        return await self._scheduler.send_wait(tx)
+        )
+        return await self._scheduler.send(tx)
     
     async def amend_order_tx(
             self,
@@ -569,16 +1049,16 @@ class ExecutionClient:
             TypedContractFunction that can be used to execute the transaction
         """
         # Get the CLOB contract
-        clob = self._clob_client.get_clob(market.address)
+        clob = self._chain_client.get_clob(market.address)
 
         # Create amend args
-        args = ICLOBAmendArgs(
-            orderId=order_id,
-            amountInBase=amount_in_base,
+        args = AmendArgs(
+            order_id=order_id,
+            amount_in_base=amount_in_base,
             price=price_in_ticks,
-            cancelTimestamp=0,  # No expiration
+            cancel_timestamp=0,  # No expiration
             side=side.value,
-            limitOrderType=LimitOrderType.POST_ONLY.value,
+            limit_order_type=LimitOrderType.POST_ONLY.value,
             settlement=Settlement.INSTANT.value,
         )
 
@@ -589,16 +1069,22 @@ class ExecutionClient:
             self,
             market: Market,
             order_id: int,
-            new_amount: Optional[int] = None,
-            new_price: Optional[int] = None,
+            side: OrderSide,
+            original_amount: Decimal | None = None,
+            original_price: Decimal | None = None,
+            new_amount: Decimal | None = None,
+            new_price: Decimal | None = None,
             **kwargs,
-    ) -> OrderAmendedEvent:
+    ) -> str:
         """
         Amend an existing order.
 
         Args:
             market: Market the order is on
             order_id: ID of the order to amend
+            side: Order side
+            original_amount: Original amount for the order
+            original_price: Original price for the order
             new_amount: New amount for the order (None to keep current)
             new_price: New price for the order (None to keep current)
             **kwargs: Additional transaction parameters
@@ -606,24 +1092,15 @@ class ExecutionClient:
         Returns:
             Transaction receipt from the amend operation
         """
-        # Get the CLOB contract
-        clob = self._clob_client.get_clob(market.address)
-
-        # Get the current order
-        order = await clob.get_order(order_id)
-
-        # Extract order details
-        side = order.side
-        current_amount = order.amount
-        current_price = order.price
-
-        amount_in_base = new_amount or current_amount
-        price_in_ticks = new_price if new_price is not None else current_price
+        amount_in_base = market.base.convert_quantity_to_amount(new_amount if new_amount else original_amount) if original_amount else 0
+        price_in_ticks = market.quote.convert_quantity_to_amount(new_price if new_price else original_price) if original_price else 0
         
-        # Ensure approval
-        token, approval_amount = self._compute_approval_requirements(market, side, amount_in_base, True, price_in_ticks)
+        if amount_in_base == 0 or price_in_ticks == 0:
+            raise ValueError("Amount or price is 0")
+        
+        token = self._chain_client.get_erc20(market.quote.address) if side == OrderSide.BUY else self._chain_client.get_erc20(market.base.address)
+        
         await self._ensure_approval(
-            amount=approval_amount,
             token=token,
             **kwargs,
         )
@@ -632,13 +1109,13 @@ class ExecutionClient:
         tx = await self.amend_order_tx(
             market=market, 
             order_id=order_id, 
-            amount_in_base=amount_in_base,
-            price_in_ticks=price_in_ticks,
+            amount_in_base=int(amount_in_base),
+            price_in_ticks=int(price_in_ticks),
             side=side,
             **kwargs
         )
-        tx = tx.with_event(clob.contract.events.OrderAmended(), parse_order_amended)
-        return await self._scheduler.send_wait(tx)
+
+        return await self._scheduler.send(tx)
 
     def cancel_order_tx(
             self, market: Market, order_id: int, **kwargs
@@ -654,18 +1131,17 @@ class ExecutionClient:
         Returns:
             TypedContractFunction that can be used to execute the transaction
         """
-        router = self._clob_client.get_router()
 
         # Create cancel args
-        args = ICLOBCancelArgs(
+        args = CancelArgs(
             [order_id], 
-            Settlement.INSTANT.value
+            Settlement.INSTANT.value          
         )
 
         # Return the router transaction
-        return router.clob_cancel(clob=market.address, args=args, isUnwrapping=False, **kwargs)
+        return self._chain_client.router.clob_cancel(clob=market.address, args=args, is_unwrapping=True, **kwargs)
 
-    async def cancel_order(self, market: Market, order_id: int, **kwargs) -> OrderCanceledEvent:
+    async def cancel_order(self, market: Market, order_id: int, **kwargs) -> str:
         """
         Cancel an existing order using the router contract.
 
@@ -677,11 +1153,11 @@ class ExecutionClient:
         Returns:
             Transaction receipt of the cancellation
         """
-        clob = self._clob_client.get_clob(market.address)
-        tx = self.cancel_order_tx(market=market, order_id=order_id, **kwargs).with_event(clob.contract.events.OrderCanceled(), parse_order_canceled)
-        return await self._scheduler.send_wait(tx)
+        clob = self._chain_client.get_clob(market.address)
+        tx = self.cancel_order_tx(market=market, order_id=order_id, **kwargs)
+        return await self._scheduler.send(tx)
 
-    async def cancel_all_orders(self, market: Market, open_orders: List[Order], **kwargs) -> List[OrderCanceledEvent]:
+    async def cancel_all_orders(self, market: Market, open_orders: List[Order], **kwargs) -> List[str]:
         """
         Cancel all orders for the current user on a specific market using the router.
 
@@ -702,22 +1178,16 @@ class ExecutionClient:
 
     def clear_approval_cache(self):
         """Clear the approval cache. Use this if you want to force re-checking approvals."""
-        self._approved_tokens.clear()
+        self._approved_clob_tokens.clear()
+        self._approved_swap_tokens.clear()
+        self._approved_launchpad_tokens.clear()
         logger.info("Approval cache cleared")
-
-    def get_approved_tokens(self) -> set[ChecksumAddress]:
-        """Get the set of tokens that are cached as approved."""
-        return self._approved_tokens.copy()
-
-    def is_token_approved(self, token_address: ChecksumAddress) -> bool:
-        """Check if a token is in the approval cache."""
-        return token_address in self._approved_tokens
 
     # ================= UTILITY OPERATIONS =================
 
     async def get_balance(
             self, token_address: ChecksumAddress, account: ChecksumAddress | None = None
-    ) -> Tuple[float, float]:
+    ) -> tuple[Decimal, Decimal]:
         """
         Get token balance for an account both on-chain and in the exchange.
 
@@ -728,23 +1198,18 @@ class ExecutionClient:
         Returns:
             Tuple of (wallet_balance, exchange_balance) in human-readable format
         """
+        token_details = await self._info.get_token(token_address)
         account = account if account else self._account.address
-        token = self._token_client.get_erc20(token_address)
+        token = self._chain_client.get_erc20(token_address)
 
         # Get wallet balance
         wallet_balance_raw = await token.balance_of(account)
-        wallet_balance = await token.convert_amount_to_quantity(wallet_balance_raw)
-
-        clob_factory = self._clob_client.clob_factory
-        if not clob_factory:
-            await self.init()
-            clob_factory = self._clob_client.clob_factory
-            assert clob_factory is not None, "CLOB factory should be initialized"
+        wallet_balance = token_details.convert_amount_to_quantity(wallet_balance_raw)
 
         # Get exchange balance
-        exchange_balance_raw = await clob_factory.get_account_balance(
+        exchange_balance_raw = await self._chain_client.clob_manager.get_account_balance(
             account, token_address
         )
-        exchange_balance = await token.convert_amount_to_quantity(exchange_balance_raw)
+        exchange_balance = token_details.convert_amount_to_quantity(exchange_balance_raw)
 
         return wallet_balance, exchange_balance


### PR DESCRIPTION
`client.execution.swap_tokens(token_in, token_out, amount_of_token_in, slippage)`
or swap for an exact output
`client.execution.swap_tokens_for_exact_output(token_in, token_out, amount_out, slippage)`
also supports quoting a swap:
`client.execution.get_swap_quote(token_in, token_out, amount_of_token_in)`

the same basic function support for launchpad buy/sell and quoting a buy/sell